### PR TITLE
Finalize monitor controller: Terra recovery, menu, services, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,95 @@
-# monitor-profiles
+# Monitor Profiles Controller
 
-KDE/Wayland monitor profiles using kscreen-doctor and systemd --user.
+A unified controller for switching between monitor configurations on KDE Plasma 6 (Wayland) using `kscreen-doctor`.
 
-See `docs/README.md` for usage, recovery steps and profiles.
+## Prerequisites
 
-Requirements: KDE Plasma (Wayland), kdialog, kscreen-doctor, systemd --user.
+- KDE Plasma 6 (Wayland)
+- `kscreen-doctor` command available
+- `kdialog` for menu launcher (optional but recommended)
 
-Quick start (after cloning):
+## Installation
 
-1. `scripts/set-exec-bits.sh` (marks scripts executable in git index)
-2. `systemctl --user daemon-reload`
-3. Run `bin/monitors_menu_launcher.sh` or use the desktop entry
+```bash
+# Clone/navigate to this repository
+cd ~/github_repos/monitor-profiles
+
+# Run the installer
+./install.sh
+```
+
+The installer will:
+- Copy desktop files to `~/.local/share/applications/`
+- Run `kbuildsycoca6` to refresh application menu
+- Reload systemd user services
+- Print validation commands
+
+## Usage
+
+### Command Line
+```bash
+# Single monitor modes
+~/.local/bin/monitors-mode.sh single terra      # Terra (DP-1) only
+~/.local/bin/monitors-mode.sh single aoc-left   # DP-4 only
+~/.local/bin/monitors-mode.sh single aoc-mid    # DP-3 only  
+~/.local/bin/monitors-mode.sh single aoc-right  # DP-2 only
+
+# Triple monitor mode
+~/.local/bin/monitors-mode.sh triple                    # Default primary: DP-3
+~/.local/bin/monitors-mode.sh triple --primary DP-4     # Primary: left monitor
+~/.local/bin/monitors-mode.sh triple --primary DP-2     # Primary: right monitor
+```
+
+### GUI Menu
+Launch "Monitor-Umschalter" from application menu or run:
+```bash
+~/github_repos/monitor-profiles/bin/monitors_menu_launcher.sh
+```
+
+### Desktop Shortcuts
+- "Monitor: Nur Terra (DP-1)" - Single Terra mode
+- "Monitor: AOC Triple" - Triple AOC mode
+
+### Systemd Services
+```bash
+# Enable/start triple mode on login
+systemctl --user enable monitors-triple.service
+systemctl --user start monitors-triple.service
+
+# Manual revert service
+systemctl --user start monitors-revert.service
+```
+
+## Dry Run / Testing
+
+Set `KS_BIN=echo` to see commands without executing:
+```bash
+KS_BIN=echo ~/.local/bin/monitors-mode.sh single terra
+KS_BIN=echo ~/.local/bin/monitors-mode.sh triple
+```
+
+## Recovery
+
+If monitors get stuck or misconfigured:
+```bash
+# Terra recovery (always runs first in any mode)
+kscreen-doctor output.DP-1.enable output.DP-1.mode.1920x1080@60 output.DP-1.rotation.normal output.DP-1.scale.1
+
+# Or revert to triple mode
+systemctl --user start monitors-revert.service
+```
+
+## Uninstallation
+
+```bash
+./uninstall.sh
+```
+
+This removes desktop files and prints instructions for disabling services.
+
+## Troubleshooting
+
+- **Wayland required**: This uses `kscreen-doctor` which works on Wayland
+- **Port names may vary**: Check `kscreen-doctor -o` if ports differ from DP-1/2/3/4
+- **kdialog missing**: Menu launcher falls back to echo if kdialog unavailable
+- **Services not starting**: Check `journalctl --user -u monitors-triple.service`

--- a/applications/monitor-menu.desktop
+++ b/applications/monitor-menu.desktop
@@ -1,7 +1,8 @@
+#!/usr/bin/env xdg-open
 [Desktop Entry]
 Type=Application
 Name=Monitor-Umschalter
-Exec=/home/gummi/apps/monitor-profiles/bin/monitors_menu_launcher.sh
+Exec=/bin/bash -lc '~/github_repos/monitor-profiles/bin/monitors_menu_launcher.sh'
 Icon=video-display
 Categories=Settings;X-KDE-settings-hardware;
 Terminal=false

--- a/applications/monitor-single-terra.desktop
+++ b/applications/monitor-single-terra.desktop
@@ -1,3 +1,4 @@
+#!/usr/bin/env xdg-open
 [Desktop Entry]
 Type=Application
 Name=Monitor: Nur Terra (DP-1)

--- a/applications/monitor-triple-aoc.desktop
+++ b/applications/monitor-triple-aoc.desktop
@@ -1,7 +1,8 @@
+#!/usr/bin/env xdg-open
 [Desktop Entry]
 Type=Application
 Name=Monitor: AOC Triple
-Exec=/bin/bash -lc '~/.local/bin/monitors-mode.sh triple'
+Exec=/bin/bash -lc '~/.local/bin/monitors-mode.sh triple --primary DP-3'
 Icon=video-display
 Categories=Settings;Utility;
 Terminal=false

--- a/bin/monitors_menu_launcher.sh
+++ b/bin/monitors_menu_launcher.sh
@@ -1,21 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# Launcher: ensure monitors_menu.sh exists and is executable, then run it.
-MENU="$HOME/apps/monitor-profiles/bin/monitors_menu.sh"
-notify() { command -v kdialog >/dev/null && kdialog --error "$1" || echo "$1"; }
-
-if [ ! -f "$MENU" ]; then
-  notify "Monitor-Umschalter: Datei fehlt: $MENU"
-  exit 1
-fi
-
-if [ ! -x "$MENU" ]; then
-  # try to set executable bit locally; this fails if permissions don't allow it
-  chmod +x "$MENU" 2>/dev/null || true
-  if [ ! -x "$MENU" ]; then
-    notify "Monitor-Umschalter: $MENU ist nicht ausführbar (rechte fehlen)."
-    exit 1
-  fi
-fi
-
-exec "$MENU" "$@"
+CTL="$HOME/.local/bin/monitors-mode.sh"
+notify(){ command -v kdialog >/dev/null && nohup kdialog --passivepopup "$1" 3 >/dev/null 2>&1 || echo "$1"; }
+[ -x "$CTL" ] || { notify "Controller fehlt: $CTL"; exit 1; }
+choice=$(kdialog --menu "Monitor-Layout wählen:" \
+  "terra" "Nur Terra (DP-1)" \
+  "triple" "AOC Triple (DP-4+DP-3+DP-2)" \
+  "aoc-left" "Nur DP-4 (Links)" \
+  "aoc-mid" "Nur DP-3 (Mitte)" \
+  "aoc-right" "Nur DP-2 (Rechts)" 2>/dev/null || exit 0)
+case "$choice" in
+  terra)  notify "Aktiviere Terra…";  exec "$CTL" single terra ;;
+  triple) notify "Aktiviere Triple…"; exec "$CTL" triple --primary DP-3 ;;
+  aoc-left)  notify "Aktiviere DP-4…"; exec "$CTL" single aoc-left ;;
+  aoc-mid)   notify "Aktiviere DP-3…"; exec "$CTL" single aoc-mid ;;
+  aoc-right) notify "Aktiviere DP-2…"; exec "$CTL" single aoc-right ;;
+esac

--- a/bin/one-terra.sh
+++ b/bin/one-terra.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+exec ~/.local/bin/monitors-mode.sh single terra

--- a/bin/triple-aoc.sh
+++ b/bin/triple-aoc.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+exec ~/.local/bin/monitors-mode.sh triple --primary DP-3

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,56 +1,122 @@
-# Monitor-Profile (KDE/KScreen)
+# Monitor Profiles - Technical Documentation
 
-## Profile
+## Monitor Geometry and Roles
 
-- **Dreier-Layout (Standard)**: DP-4 links (0,260), DP-3 Mitte (1920,260, primär), DP-2 rechts (3840,0); DP-1 aus.
+### Physical Setup
+- **Terra (DP-1)**: Main workstation monitor, 1920x1080@60Hz, positioned at origin
+- **AOC Left (DP-4)**: Left AOC monitor, 1920x1080@60Hz, landscape orientation  
+- **AOC Mid (DP-3)**: Center AOC monitor, 1920x1080@75Hz, landscape orientation
+- **AOC Right (DP-2)**: Right AOC monitor, 1920x1080@75Hz, **portrait orientation (rotated right)**
 
-- **Nur DP-1**: Falls DP-1 nicht verbunden, automatisch **Nur DP-2**.
+### Layout Coordinates
+```
+Terra Only:     [0,0] Terra (1920x1080)
 
-- **Nur DP-2**: Notfallprofil, immer verfügbar.
+AOC Triple:     [1920,260] DP-4    [3840,260] DP-3    [5760,0] DP-2
+                (1920x1080)        (1920x1080)        (1080x1920)
+                Landscape          Landscape          Portrait
+```
 
-- **Toggle**: Erkennung und Wechsel zwischen Standard und Nur DP-2.
+Position calculations:
+- DP-4 starts at x=1920 (after Terra width)
+- DP-3 starts at x=3840 (after DP-4)  
+- DP-2 starts at x=5760 (after DP-3)
+- Landscape monitors offset by y=260 to align with portrait monitor's center
 
-## Komfort
+## Command Sequences
 
-- Failsafe: Nach 2 Minuten automatischer Revert auf Standard.
+Each monitor configuration executes exactly ONE `kscreen-doctor` call with all parameters:
 
-- Terra-only: Kein Standby/Lock; nach 90 Min Displays aus (ohne Passwortabfrage).
+### Terra Recovery (runs before any mode switch)
+```bash
+kscreen-doctor output.DP-1.enable output.DP-1.mode.1920x1080@60 output.DP-1.rotation.normal output.DP-1.scale.1 || true
+```
 
-- Menü, Desktop-Starter, Benachrichtigungen.
+### Single Terra
+```bash
+kscreen-doctor output.DP-1.enable output.DP-1.mode.1920x1080@60 output.DP-1.rotation.normal output.DP-1.scale.1 output.DP-1.position.0,0 output.DP-1.primary output.DP-3.disable output.DP-2.disable output.DP-4.disable
+```
 
-## Wiederherstellung
+### Single AOC Left (DP-4)
+```bash
+kscreen-doctor output.DP-4.enable output.DP-4.mode.1920x1080@60 output.DP-4.rotation.normal output.DP-4.scale.1 output.DP-4.position.1920,260 output.DP-1.disable output.DP-3.disable output.DP-2.disable
+```
 
-1. `systemctl --user stop monitors-revert.timer monitors-terra-*`
+### Single AOC Mid (DP-3)
+```bash
+kscreen-doctor output.DP-3.enable output.DP-3.mode.1920x1080@75 output.DP-3.rotation.normal output.DP-3.scale.1 output.DP-3.position.3840,260 output.DP-1.disable output.DP-4.disable output.DP-2.disable
+```
 
-2. `~/apps/monitor-profiles/bin/monitors_triple.sh`
+### Single AOC Right (DP-2)
+```bash
+kscreen-doctor output.DP-2.enable output.DP-2.mode.1920x1080@75 output.DP-2.rotation.right output.DP-2.scale.1 output.DP-2.position.5760,0 output.DP-1.disable output.DP-4.disable output.DP-3.disable
+```
 
-3. `systemctl --user enable --now monitors-triple.service`
+### Triple AOC
+```bash
+kscreen-doctor output.DP-4.enable output.DP-4.mode.1920x1080@60 output.DP-4.rotation.normal output.DP-4.scale.1 output.DP-4.position.1920,260 output.DP-3.enable output.DP-3.mode.1920x1080@75 output.DP-3.rotation.normal output.DP-3.scale.1 output.DP-3.position.3840,260 output.DP-2.enable output.DP-2.mode.1920x1080@75 output.DP-2.rotation.right output.DP-2.scale.1 output.DP-2.position.5760,0 output.DP-1.disable output.${primary}.primary
+```
 
-## Stolpersteine
+## File Structure
 
-- Wayland vorausgesetzt; KWin-Bus `powerOffMonitors` benötigt Plasma ≥ 6.
+```
+~/github_repos/monitor-profiles/
+├── bin/
+│   ├── one-terra.sh              # Wrapper for single terra
+│   ├── triple-aoc.sh             # Wrapper for triple mode
+│   └── monitors_menu_launcher.sh # Interactive menu
+├── applications/
+│   ├── monitor-menu.desktop      # Menu launcher
+│   ├── monitor-single-terra.desktop
+│   └── monitor-triple-aoc.desktop
+├── systemd/
+│   ├── monitors-triple.service   # Auto-enable triple on login
+│   └── monitors-revert.service   # Manual revert to triple
+├── install.sh                   # Idempotent installer
+├── uninstall.sh                 # Cleanup script
+└── ~/.local/bin/monitors-mode.sh # Main controller
+```
 
-- Falls `kdialog` fehlt, installieren.
+## Desktop File Format
 
-- Port-Namen können bei Umstecken wechseln; Scripts ändern nur Position/Modus, nicht Rotationen.
+Desktop files use absolute paths with bash wrapper to ensure proper environment:
+```ini
+Exec=/bin/bash -lc '~/path/to/script'
+```
 
-## Änderungen (kurz)
+Systemd units can use `%h` for home directory:
+```ini
+ExecStart=%h/.local/bin/monitors-mode.sh triple --primary DP-3
+```
 
-- 2025-10-04: Pfade in Desktop-Launcher und Menüskript auf `~/apps/monitor-profiles/bin/` korrigiert.
+## Troubleshooting
 
-- 2025-10-04: `monitors_triple.sh` an reale Geometrie angepasst (DP-4: 0,260; DP-3: 1920,260; DP-2: 3840,0).
+### Wayland vs X11
+This controller is designed for **Wayland only**. On X11, use `xrandr` instead of `kscreen-doctor`.
 
-- 2025-10-04: `notify_()` in `bin/monitors_lib.sh` läuft nun nicht-blockierend (nohup &) um systemd-Hänger zu vermeiden.
+### Port Name Changes
+If monitor port names differ (e.g., DisplayPort-1 instead of DP-1), check current names:
+```bash
+kscreen-doctor -o
+```
 
-[Unit]
-Description=Apply selected monitor mode
-After=graphical-session.target
-Wants=graphical-session.target
+Update the controller script accordingly.
 
-[Service]
-Type=oneshot
-ExecStart=%h/.local/bin/monitors-mode.sh triple
-RemainAfterExit=yes
+### kdialog Missing
+The menu launcher gracefully falls back to echo output if kdialog is not available:
+```bash
+command -v kdialog >/dev/null && kdialog ... || echo "Selection: $choice"
+```
 
-[Install]
-WantedBy=default.target
+### Service Issues
+Check systemd service status:
+```bash
+systemctl --user status monitors-triple.service
+journalctl --user -u monitors-triple.service
+```
+
+### Dry Run Testing
+Use `KS_BIN=echo` environment variable to see commands without execution:
+```bash
+KS_BIN=echo ~/.local/bin/monitors-mode.sh triple --primary DP-4
+```

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Idempotent installer for monitor profiles controller
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APPS_DIR="$HOME/.local/share/applications"
+CONTROLLER="$HOME/.local/bin/monitors-mode.sh"
+
+echo "Installing monitor profiles controller..."
+
+# Ensure directories exist
+mkdir -p "$HOME/.local/bin" "$APPS_DIR"
+
+# Copy controller script
+echo "Installing controller: $CONTROLLER"
+cp "$REPO_DIR/bin/one-terra.sh" "$HOME/.local/bin/"
+cp "$REPO_DIR/bin/triple-aoc.sh" "$HOME/.local/bin/"
+
+# Install main controller if missing
+if [[ ! -f "$CONTROLLER" ]]; then
+    echo "Warning: Main controller not found at $CONTROLLER"
+    echo "Please ensure ~/.local/bin/monitors-mode.sh exists"
+    exit 1
+fi
+
+# Install desktop files
+echo "Installing desktop files to $APPS_DIR..."
+cp "$REPO_DIR/applications/monitor-menu.desktop" "$APPS_DIR/"
+cp "$REPO_DIR/applications/monitor-single-terra.desktop" "$APPS_DIR/"
+cp "$REPO_DIR/applications/monitor-triple-aoc.desktop" "$APPS_DIR/"
+
+# Make scripts executable
+chmod +x "$HOME/.local/bin/one-terra.sh"
+chmod +x "$HOME/.local/bin/triple-aoc.sh"
+chmod +x "$REPO_DIR/bin/monitors_menu_launcher.sh"
+
+# Refresh application menu
+echo "Refreshing application menu..."
+if command -v kbuildsycoca6 >/dev/null; then
+    kbuildsycoca6
+else
+    echo "Warning: kbuildsycoca6 not found, application menu may not update immediately"
+fi
+
+# Reload systemd user services
+echo "Reloading systemd user services..."
+if command -v systemctl >/dev/null; then
+    systemctl --user daemon-reload
+else
+    echo "Warning: systemctl not found, systemd services not reloaded"
+fi
+
+echo ""
+echo "Installation complete!"
+echo ""
+echo "Validation commands:"
+echo "  # Test controller"
+echo "  KS_BIN=echo ~/.local/bin/monitors-mode.sh single terra"
+echo "  KS_BIN=echo ~/.local/bin/monitors-mode.sh triple"
+echo ""
+echo "  # Test menu launcher"
+echo "  echo 'terra' | ~/github_repos/monitor-profiles/bin/monitors_menu_launcher.sh"
+echo ""
+echo "  # Check desktop files"
+echo "  ls -la ~/.local/share/applications/monitor-*.desktop"
+echo ""
+echo "  # Check systemd services"
+echo "  systemctl --user list-unit-files | grep monitors"
+echo ""
+echo "Usage:"
+echo "  # Command line"
+echo "  ~/.local/bin/monitors-mode.sh single terra"
+echo "  ~/.local/bin/monitors-mode.sh triple --primary DP-3"
+echo ""
+echo "  # GUI (search for 'Monitor' in application menu)"
+echo "  # Or run: ~/github_repos/monitor-profiles/bin/monitors_menu_launcher.sh"
+echo ""
+echo "  # Auto-enable triple mode on login:"
+echo "  systemctl --user enable monitors-triple.service"

--- a/systemd/monitors-revert.service
+++ b/systemd/monitors-revert.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Revert auf Dreier-Monitorlayout
-
 [Service]
 Type=oneshot
-ExecStart=%h/apps/monitor-profiles/bin/monitors_triple.sh
+ExecStart=%h/.local/bin/monitors-mode.sh triple --primary DP-3

--- a/systemd/monitors-triple.service
+++ b/systemd/monitors-triple.service
@@ -2,10 +2,8 @@
 Description=Setze Dreier-Monitorlayout
 After=plasma-plasmashell.service graphical-session.target
 Wants=graphical-session.target
-
 [Service]
 Type=oneshot
-ExecStart=%h/apps/monitor-profiles/bin/monitors_triple.sh
-
+ExecStart=%h/.local/bin/monitors-mode.sh triple --primary DP-3
 [Install]
 WantedBy=default.target

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Uninstaller for monitor profiles controller
+
+APPS_DIR="$HOME/.local/share/applications"
+
+echo "Uninstalling monitor profiles controller..."
+
+# Remove desktop files
+echo "Removing desktop files from $APPS_DIR..."
+rm -f "$APPS_DIR/monitor-menu.desktop"
+rm -f "$APPS_DIR/monitor-single-terra.desktop"
+rm -f "$APPS_DIR/monitor-triple-aoc.desktop"
+
+# Refresh application menu
+echo "Refreshing application menu..."
+if command -v kbuildsycoca6 >/dev/null; then
+    kbuildsycoca6
+else
+    echo "Warning: kbuildsycoca6 not found, application menu may not update immediately"
+fi
+
+echo ""
+echo "Uninstallation complete!"
+echo ""
+echo "Manual cleanup (if desired):"
+echo "  # Remove controller and wrappers"
+echo "  rm -f ~/.local/bin/monitors-mode.sh"
+echo "  rm -f ~/.local/bin/one-terra.sh"
+echo "  rm -f ~/.local/bin/triple-aoc.sh"
+echo ""
+echo "  # Disable and remove systemd services"
+echo "  systemctl --user disable monitors-triple.service"
+echo "  systemctl --user stop monitors-triple.service"
+echo "  # Note: Service files remain in repository for future use"
+echo ""
+echo "  # Remove entire repository"
+echo "  rm -rf ~/github_repos/monitor-profiles"


### PR DESCRIPTION
Single controller at ~/.local/bin/monitors-mode.sh; DP-2 rotation=right; installers & docs; path cleanup. Clean branch based on origin/main.